### PR TITLE
Fix output filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: intl.dll
 
 intl.dll: win_intl.c
-	$(CC) /Fe:$@ /LD /MD $** /link /DEF:intl.def
+	$(CC) /Fe$@ /LD /MD $** /link /DEF:intl.def
 
 clean:
 	del *.dll *.obj *.exp *.lib


### PR DESCRIPTION
Output filename was wrong. Alternate Data Streams named ":intl.{dll,lib,exp}" were wrongly created.
